### PR TITLE
feat: use tcp adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,18 @@
           "type": "boolean",
           "default": true,
           "description": "Whether to start the Credo Language Server."
+        },
+        "elixir-tools.credo.adapter": {
+          "type": "string",
+          "enum": ["stdio", "tcp"],
+          "default": "stdio",
+          "description": "Which adapter to use when connecting to credo-language-server"
+
+        },
+        "elixir-tools.credo.port": {
+          "type": "integer",
+           "default": 9000,
+          "description": "If adapter is `tcp`, use this port to connect."
         }
       }
     },


### PR DESCRIPTION
Adds the settings to attach to an existing instance of credo-language-server over TCP.

This is useful for debugging.
