### PR TITLE
feat: add version configuration to CredoLS and NextLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "elixir-tools.credo.enable": {
           "type": "boolean",
           "default": true,
-          "description": "Whether to start the Credo Language Server."
+          "markdownDescription": "Whether to start the _Credo Language Server_."
         },
         "elixir-tools.credo.adapter": {
           "type": "string",
@@ -44,17 +44,22 @@
             "tcp"
           ],
           "default": "stdio",
-          "description": "Which adapter to use when connecting to credo-language-server"
+          "markdownDescription": "Which adapter to use when connecting to the _Credo Language Server_."
         },
         "elixir-tools.credo.port": {
           "type": "integer",
           "default": 9000,
-          "description": "If adapter is `tcp`, use this port to connect."
+          "markdownDescription": "If adapter is `tcp`, use this port to connect."
+        },
+        "elixir-tools.credo.version": {
+          "type": "string",
+          "default": "latest",
+          "markdownDescription": "Defines specific version of the _Credo Language Server_.\n\nThe default `latest` value dynamically gets the latest release from the Github when extension is activated."
         },
         "elixir-tools.nextls.enable": {
           "type": "boolean",
           "default": false,
-          "description": "Whether to start NextLS."
+          "markdownDescription": "Whether to start the _NextLS_."
         },
         "elixir-tools.nextls.adapter": {
           "type": "string",
@@ -63,12 +68,17 @@
             "tcp"
           ],
           "default": "stdio",
-          "description": "Which adapter to use when connecting to NextLS"
+          "markdownDescription": "Which adapter to use when connecting to the _NextLS_."
         },
         "elixir-tools.nextls.port": {
           "type": "integer",
           "default": 9000,
-          "description": "If adapter is `tcp`, use this port to connect."
+          "markdownDescription": "If adapter is `tcp`, use this port to connect."
+        },
+        "elixir-tools.nextls.version": {
+          "type": "string",
+          "default": "latest",
+          "markdownDescription": "Defines specific version of the _NextLS_.\n\nThe default `latest` value dynamically gets the latest release from the Github when extension is activated."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "elixir-tools.credo.enable": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Whether to start **Credo Language Server_**"
+          "markdownDescription": "Whether to start **Credo Language Server**"
         },
         "elixir-tools.credo.adapter": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "elixir-tools.credo.enable": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Whether to start the _Credo Language Server_."
+          "markdownDescription": "Whether to start **Credo Language Server_**"
         },
         "elixir-tools.credo.adapter": {
           "type": "string",
@@ -44,7 +44,7 @@
             "tcp"
           ],
           "default": "stdio",
-          "markdownDescription": "Which adapter to use when connecting to the _Credo Language Server_."
+          "markdownDescription": "Which adapter to use when connecting to **Credo Language Server**."
         },
         "elixir-tools.credo.port": {
           "type": "integer",
@@ -54,12 +54,12 @@
         "elixir-tools.credo.version": {
           "type": "string",
           "default": "latest",
-          "markdownDescription": "Defines specific version of the _Credo Language Server_.\n\nThe default `latest` value dynamically gets the latest release from the Github when extension is activated."
+          "markdownDescription": "Specifies the version of **Credo Language Server**.\n\nDefaults to `latest`."
         },
         "elixir-tools.nextls.enable": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Whether to start the _NextLS_."
+          "markdownDescription": "Whether to start **Next LS**."
         },
         "elixir-tools.nextls.adapter": {
           "type": "string",
@@ -68,7 +68,7 @@
             "tcp"
           ],
           "default": "stdio",
-          "markdownDescription": "Which adapter to use when connecting to the _NextLS_."
+          "markdownDescription": "Which adapter to use when connecting to **Next LS**."
         },
         "elixir-tools.nextls.port": {
           "type": "integer",
@@ -78,7 +78,7 @@
         "elixir-tools.nextls.version": {
           "type": "string",
           "default": "latest",
-          "markdownDescription": "Defines specific version of the _NextLS_.\n\nThe default `latest` value dynamically gets the latest release from the Github when extension is activated."
+          "markdownDescription": "Specifies the version of **Next LS**.\n\nDefaults to `latest`."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,12 +39,16 @@ async function activateCredo(
 
       switch (config.get("adapter")) {
         case "stdio":
+          let version = config.get("version");
+
+          if (version === "latest") {
+            version = await latestRelease("credo-language-server");
+          }
+
           serverOptions = {
             options: {
               env: Object.assign({}, process.env, {
-                ["CREDO_LSP_VERSION"]: await latestRelease(
-                  "credo-language-server"
-                ),
+                ["CREDO_LSP_VERSION"]: version,
               }),
             },
             command: context.asAbsolutePath("./bin/credo-language-server"),
@@ -96,10 +100,16 @@ async function activateNextLS(
 
     switch (config.get("adapter")) {
       case "stdio":
+        let version = config.get("version");
+
+        if (version === "latest") {
+          version = await latestRelease("next-ls");
+        }
+
         serverOptions = {
           options: {
             env: Object.assign({}, process.env, {
-              ["NEXTLS_VERSION"]: await latestRelease("next-ls"),
+              ["NEXTLS_VERSION"]: version,
             }),
           },
           command: context.asAbsolutePath("./bin/nextls"),


### PR DESCRIPTION
closes #14 

I've also updated the description of existing properties to use Markdown. Result:

<img width="1315" alt="image" src="https://github.com/elixir-tools/elixir-tools.vscode/assets/929818/be037b42-9602-499f-8bb4-4f90789f2527">


I manually tested all works as expected:
- Outputs with CredoLS set to `0.1.3`:
  <img width="510" alt="image" src="https://github.com/elixir-tools/elixir-tools.vscode/assets/929818/73af89bd-9da4-43ba-bc94-e69f66a28dda">

- Outputs with CredoLS set to `0.2.0`:
  <img width="524" alt="image" src="https://github.com/elixir-tools/elixir-tools.vscode/assets/929818/3fc30590-fb75-47db-b439-6f721281e0cc">
- Outputs with NextLS set to `0.4.0`:
  <img width="721" alt="image" src="https://github.com/elixir-tools/elixir-tools.vscode/assets/929818/b13191e2-aca8-4f4c-8414-43061622bd4e">
- Outputs with NextLS set to `0.5.2`:  
  <img width="629" alt="image" src="https://github.com/elixir-tools/elixir-tools.vscode/assets/929818/6c4ef4dc-6627-43bc-8cd3-18e131fec602">
