### PR TITLE
refactor!: reorganize configuration settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "properties": {
           "elixir-tools.nextLS.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "Whether to start **Next LS**.",
             "order": 1
           },
@@ -84,7 +84,7 @@
         "properties": {
           "elixir-tools.credo.enable": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "markdownDescription": "Whether to start **Credo Language Server**",
             "order": 1
           },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "elixir-tools",
-  "displayName": "elixir-tools.vscode",
+  "displayName": "elixir-tools",
   "homepage": "https://github.com/elixir-tools/elixir-tools.vscode",
-  "description": "Elixir extension for VSCode.",
+  "description": "Elixir extension with support for Next LS and Credo Language Server",
   "publisher": "elixir-tools",
   "version": "0.8.0",
   "repository": {
@@ -37,81 +37,90 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
-    "configuration": {
-      "title": "elixir-tools",
-      "properties": {
-        "elixir-tools.credo.enable": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Whether to start **Credo Language Server**"
-        },
-        "elixir-tools.credo.adapter": {
-          "type": "string",
-          "enum": [
-            "stdio",
-            "tcp"
-          ],
-          "default": "stdio",
-          "markdownDescription": "Which adapter to use when connecting to **Credo Language Server**."
-        },
-        "elixir-tools.credo.port": {
-          "type": "integer",
-          "default": 9000,
-          "markdownDescription": "If adapter is `tcp`, use this port to connect to a running server.\n\nYou can start the server with `path/to/credo-language-server --port <port>`."
-        },
-        "elixir-tools.credo.version": {
-          "type": "string",
-          "default": "latest",
-          "markdownDescription": "Specifies the version of **Credo Language Server**.\n\nDefaults to `latest`."
-        },
-        "elixir-tools.credo.trace.server": {
-          "type": "string",
-          "scope": "window",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the Next LS."
-        },
-        "elixir-tools.nextls.enable": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Whether to start **Next LS**."
-        },
-        "elixir-tools.nextls.adapter": {
-          "type": "string",
-          "enum": [
-            "stdio",
-            "tcp"
-          ],
-          "default": "stdio",
-          "markdownDescription": "Which adapter to use when connecting to **Next LS**."
-        },
-        "elixir-tools.nextls.port": {
-          "type": "integer",
-          "default": 9000,
-          "markdownDescription": "If adapter is `tcp`, use this port to connect to a running server.\n\nYou can start the server with `path/to/nextls --port <port>`."
-        },
-        "elixir-tools.nextls.installationDirectory": {
-          "type": "string",
-          "default": "~/.cache/elixir-tools/nextls/bin/",
-          "markdownDescription": "Overrides the default installation directory for the **Next LS** server binary."
-        },
-        "elixir-tools.nextls.trace.server": {
-          "type": "string",
-          "scope": "window",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the Next LS."
+    "configuration": [
+      {
+        "title": "Next LS",
+        "properties": {
+          "elixir-tools.nextLS.enable": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Whether to start **Next LS**.",
+            "order": 1
+          },
+          "elixir-tools.nextLS.adapter": {
+            "type": "string",
+            "enum": [
+              "stdio",
+              "tcp"
+            ],
+            "default": "stdio",
+            "markdownDescription": "Which adapter to use when connecting to **Next LS**."
+          },
+          "elixir-tools.nextLS.port": {
+            "type": "integer",
+            "default": 9000,
+            "markdownDescription": "If adapter is `tcp`, use this port to connect to a running server.\n\nYou can start the server with `path/to/nextls --port <port>`."
+          },
+          "elixir-tools.nextLS.installationDirectory": {
+            "type": "string",
+            "default": "~/.cache/elixir-tools/nextls/bin/",
+            "markdownDescription": "Overrides the default installation directory for the **Next LS** server binary."
+          },
+          "elixir-tools.nextLS.trace.server": {
+            "type": "string",
+            "scope": "window",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "default": "off",
+            "description": "Traces the communication between VS Code and the Next LS."
+          }
+        }
+      },
+      {
+        "title": "Credo Language Server",
+        "properties": {
+          "elixir-tools.credo.enable": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Whether to start **Credo Language Server**",
+            "order": 1
+          },
+          "elixir-tools.credo.adapter": {
+            "type": "string",
+            "enum": [
+              "stdio",
+              "tcp"
+            ],
+            "default": "stdio",
+            "markdownDescription": "Which adapter to use when connecting to **Credo Language Server**."
+          },
+          "elixir-tools.credo.port": {
+            "type": "integer",
+            "default": 9000,
+            "markdownDescription": "If adapter is `tcp`, use this port to connect to a running server.\n\nYou can start the server with `path/to/credo-language-server --port <port>`."
+          },
+          "elixir-tools.credo.version": {
+            "type": "string",
+            "default": "latest",
+            "markdownDescription": "Specifies the version of **Credo Language Server**.\n\nDefaults to `latest`."
+          },
+          "elixir-tools.credo.trace.server": {
+            "type": "string",
+            "scope": "window",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "default": "off",
+            "description": "Traces the communication between VS Code and the Next LS."
+          }
         }
       }
-    },
+    ],
     "languages": [
       {
         "id": "elixir",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ async function activateNextLS(
   context: vscode.ExtensionContext,
   _mixfile: vscode.Uri
 ) {
-  let config = vscode.workspace.getConfiguration("elixir-tools.nextls");
+  let config = vscode.workspace.getConfiguration("elixir-tools.nextLS");
 
   const command = "elixir-tools.uninstall-nextls";
 
@@ -177,7 +177,7 @@ async function activateNextLS(
     };
 
     nextLSClient = new LanguageClient(
-      "elixir-tools.nextls",
+      "elixir-tools.nextLS",
       "NextLS",
       serverOptions,
       clientOptions


### PR DESCRIPTION
This PR organizes the extension's config settings and renames the Next LS setting prefix to improve setting legibility.

**Summary of changes:**

* Split settings into "Next LS" and "Credo LS" section, in that order.
* Add an `"order"` attribute to the `*.enable` properties so that they come first.
* Rename  `"elixir-tools.nextls.*"` to `"elixir-tools.nextLS.*"`. This causes properties to render as "Next LS: *" instead of "Nextls: *".

**Before:**

![settings-before](https://github.com/elixir-tools/elixir-tools.vscode/assets/503938/0aabf508-4b17-4acd-a61b-3d0de36684c6)

**After:**

![settings-after](https://github.com/elixir-tools/elixir-tools.vscode/assets/503938/3adf2b96-730a-48eb-8de0-2d103407695b)
