### PR TITLE
docs: update README.md with VSCodium link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ elixir-tools.vscode provides support for:
 
 ## Install
 
+### From VSCode
+
 Install from the extension [marketplace](https://marketplace.visualstudio.com/items?itemName=elixir-tools.elixir-tools).
+
+### From VSCodium
+
+Install from the extension [marketplace](https://open-vsx.org/extension/elixir-tools/elixir-tools).
 
 ### From Source
 


### PR DESCRIPTION
Because of how the site works it's not clear if you have control of the the VSCodium [marketplace extension page](https://open-vsx.org/extension/elixir-tools/elixir-tools). 

Having a (more explicit) link from the official repo to the extension page would increase trust that you are the publisher on this site.

Thanks for creating a great set of tools.